### PR TITLE
fix fuse conv batchnorm subsitition bug

### DIFF
--- a/include/taso/ops.h
+++ b/include/taso/ops.h
@@ -360,37 +360,6 @@ struct Tensor {
     return true;
   }
 
-  void print_info(string name) const{
-    printf("%s address:%x\n", name.c_str(), data_ptr);
-    float* h_data_ptr = new float[volume()];
-    cudaMemcpy(h_data_ptr, data_ptr, volume()*sizeof(float), cudaMemcpyDeviceToHost);
-    int ndim = numDim;
-    int dims[4] = {0};
-    for (int i=0; i < ndim; i++) dims[i] = dim[i];
-    if (ndim==4) {
-      for(int i=0;i<1; i++) {
-        for(int j=0;j<dims[1]; j++) {
-          for(int k=0; k<dims[2]; k++) {
-            for(int q=0; q<dims[3]; q++) {
-              printf("%f ", *(h_data_ptr + ((((i * dims[1]) + j)*dims[2])+k)*dims[3] + q));
-            }
-            printf("\n");
-          }
-          printf("\n");
-        }
-        printf("\n");
-      }
-      printf("\n");
-    }
-    else {
-      for(int i=0;i<dims[0]; i++) {
-        printf("%f ", *( h_data_ptr + i));
-      }
-      printf("\n");
-    }
-    delete[] h_data_ptr;
-  }
-
   //bool operator==(const Tensor& b);
   int numDim, dim[MAX_DIM], stride[MAX_DIM];
   int idx; // idx is used for Ops with multiple outputs (e.g., split)

--- a/include/taso/ops.h
+++ b/include/taso/ops.h
@@ -356,6 +356,38 @@ struct Tensor {
     }
     return true;
   }
+
+  void print_info(string name) const{
+    printf("%s address:%x\n", name.c_str(), data_ptr);
+    float* h_data_ptr = new float[volume()];
+    cudaMemcpy(h_data_ptr, data_ptr, volume()*sizeof(float), cudaMemcpyDeviceToHost);
+    int ndim = numDim;
+    int dims[4] = {0};
+    for (int i=0; i < ndim; i++) dims[i] = dim[i];
+    if (ndim==4) {
+      for(int i=0;i<1; i++) {
+        for(int j=0;j<dims[1]; j++) {
+          for(int k=0; k<dims[2]; k++) {
+            for(int q=0; q<dims[3]; q++) {
+              printf("%f ", *(h_data_ptr + ((((i * dims[1]) + j)*dims[2])+k)*dims[3] + q));
+            }
+            printf("\n");
+          }
+          printf("\n");
+        }
+        printf("\n");
+      }
+      printf("\n");
+    }
+    else {
+      for(int i=0;i<dims[0]; i++) {
+        printf("%f ", *( h_data_ptr + i));
+      }
+      printf("\n");
+    }
+    delete[] h_data_ptr;
+  }
+
   //bool operator==(const Tensor& b);
   int numDim, dim[MAX_DIM], stride[MAX_DIM];
   int idx; // idx is used for Ops with multiple outputs (e.g., split)

--- a/include/taso/ops.h
+++ b/include/taso/ops.h
@@ -133,6 +133,8 @@ enum OpType {
   OP_PRELU, //https://github.com/onnx/onnx/blob/master/docs/Operators.md#PRelu
   OP_FUSE_CONV_BATCHNORM,
   OP_FUSE_CONV_BATCHNORM_ALPHA_VAR,
+  OP_FUSE_CONV_BATCHNORM_BIAS,
+  OP_BROADCAST_ADD
 };
 
 struct Op {
@@ -488,6 +490,8 @@ public:
          Model* _model, OpType _type);
   OpBase(const Tensor& input0, const Tensor& input1, const Tensor& input2,
          Model* _model, OpType _type);
+  OpBase(const Tensor& input0, const Tensor& input1, const Tensor& input2,
+         const Tensor& input3, Model* _model, OpType _type);
   OpBase(const Tensor& input0, const Tensor& input1,
          const Tensor& input2, const Tensor& input3,
          const Tensor& input4, Model* _model, OpType _type);
@@ -570,6 +574,12 @@ public:
   // TensorHandle fuse_conv_batchnorm_alpha_var(const TensorHandle _conv_w,
   //                                  const TensorHandle _scale,
   //                                  const TensorHandle _var);
+  TensorHandle fuse_conv_batchnorm_bias(const TensorHandle _scale,
+                                   const TensorHandle _bias,
+                                   const TensorHandle _mean,
+                                   const TensorHandle _var);
+  TensorHandle broadcast_add(const TensorHandle _data,
+                                   const TensorHandle _bias);
 
   TensorHandle leakyrelu(const TensorHandle _input, float _alpha,
                          bool _inplace=true);
@@ -938,6 +948,29 @@ public:
   void collect_costs(float& exe_time, float& flops, float& mem_acc, int& num_kernels);
 };
 
+class FuseConvBatchNormBias : public OpBase {
+public:
+  FuseConvBatchNormBias(Model* _model, const Tensor& _scale,
+                    const Tensor& _bias, const Tensor& _mean, const Tensor& _var);
+  ~FuseConvBatchNormBias(void);
+  bool get_int_parameter(PMParameter para, int*);
+  void forward(bool block);
+  void map(void);
+  void unmap(void);
+  void collect_costs(float& exe_time, float& flops, float& mem_acc, int& num_kernels);
+};
+
+class BroadcastAdd : public OpBase {
+public:
+  BroadcastAdd(Model* _model, const Tensor& _data, const Tensor& _bias);
+  ~BroadcastAdd(void);
+  bool get_int_parameter(PMParameter para, int*);
+  void forward(bool block);
+  void map(void);
+  void unmap(void);
+  void collect_costs(float& exe_time, float& flops, float& mem_acc, int& num_kernels);
+};
+
 class MergeGConv : public OpBase {
 public:
   MergeGConv(Model* _model, const Tensor& _weight, int count);
@@ -1203,9 +1236,21 @@ struct FuseConvBatchNormKey {
   int keys[KEY_LENGTH];
 };
 
+struct FuseConvBatchNormBiasKey {
+  static const int KEY_LENGTH = Tensor::MAX_KEY_LENGTH;
+  FuseConvBatchNormBiasKey(const Tensor& _scale);
+  int keys[KEY_LENGTH];
+};
+
 struct FuseConvBatchNormAlphaVarKey {
   static const int KEY_LENGTH = Tensor::MAX_KEY_LENGTH;
   FuseConvBatchNormAlphaVarKey(const Tensor& conv_w);
+  int keys[KEY_LENGTH];
+};
+
+struct BroadcastAddKey {
+  static const int KEY_LENGTH = Tensor::MAX_KEY_LENGTH;
+  BroadcastAddKey(const Tensor& data);
   int keys[KEY_LENGTH];
 };
 
@@ -1353,6 +1398,12 @@ public:
   Op get_or_create_fuse_conv_batchnorm_alpha_var(const Tensor& _conv_w,
                                        const Tensor& _scale,
                                        const Tensor& _var);
+  Op get_or_create_fuse_conv_batchnorm_bias(const Tensor& _scale,
+                                       const Tensor& _bias,
+                                       const Tensor& _mean,
+                                       const Tensor& _var);
+  Op get_or_create_broadcast_add(const Tensor& _data,
+                                 const Tensor& _bias);
   Op get_or_create_matmul(Tensor _input, Tensor _weight,
                           ActiMode _actimode);
   Op get_or_create_mul(const Tensor& x,
@@ -1460,6 +1511,8 @@ public:
   std::map<EnlargeKey, Enlarge*, KeyCompare<EnlargeKey> > enlarge;
   std::map<FuseConvBatchNormKey, FuseConvBatchNorm*, KeyCompare<FuseConvBatchNormKey> > fuse_conv_batchnorm;
   std::map<FuseConvBatchNormAlphaVarKey, FuseConvBatchNormAlphaVar*, KeyCompare<FuseConvBatchNormAlphaVarKey> > fuse_conv_batchnorm_alpha_var;
+  std::map<FuseConvBatchNormBiasKey, FuseConvBatchNormBias*, KeyCompare<FuseConvBatchNormBiasKey> > fuse_conv_batchnorm_bias;
+  std::map<BroadcastAddKey, BroadcastAdd*, KeyCompare<BroadcastAddKey> > broadcast_add;
   std::map<MatmulKey, Matmul*, KeyCompare<MatmulKey> > matmul;
   std::map<MergeGConvKey, MergeGConv*, KeyCompare<MergeGConvKey> > merge_gconv;
   std::map<MulKey, Mul*, KeyCompare<MulKey> > mul;

--- a/include/taso/substitution.h
+++ b/include/taso/substitution.h
@@ -69,6 +69,7 @@ public:
   OpX(const OpX& _op);
   OpX(OpType _type, TensorX input0, int numOutputs = 1);
   OpX(OpType _type, TensorX input0, TensorX input1);
+  OpX(OpType _type, TensorX input0, TensorX input1, TensorX input2);
   OpX(OpType _type, TensorX input0, TensorX input1, TensorX input2, TensorX input3, TensorX input4);
   OpX(OpType _type, int n, TensorX* ins);
   bool add_pm_constraint(Compare comp, PMParameter para, int value);
@@ -162,6 +163,8 @@ public:
   OpX* create_fuse_conv_batchnorm(TensorX conv_w, TensorX scale,
                                   TensorX bias, TensorX mean, TensorX var,
                                   bool isSrcOp = true);
+  OpX* create_fuse_conv_batchnorm_alpha_var(TensorX conv_w, TensorX scale, 
+                                            TensorX var, bool isSrcOp = true);
   OpX* create_pool2d_avg(TensorX input, TensorX weight,
                          //int kernelH, int kernelW,
                          int strideH, int strideW,

--- a/include/taso/substitution.h
+++ b/include/taso/substitution.h
@@ -70,6 +70,7 @@ public:
   OpX(OpType _type, TensorX input0, int numOutputs = 1);
   OpX(OpType _type, TensorX input0, TensorX input1);
   OpX(OpType _type, TensorX input0, TensorX input1, TensorX input2);
+  OpX(OpType _type, TensorX input0, TensorX input1, TensorX input2, TensorX input3);
   OpX(OpType _type, TensorX input0, TensorX input1, TensorX input2, TensorX input3, TensorX input4);
   OpX(OpType _type, int n, TensorX* ins);
   bool add_pm_constraint(Compare comp, PMParameter para, int value);
@@ -165,6 +166,10 @@ public:
                                   bool isSrcOp = true);
   OpX* create_fuse_conv_batchnorm_alpha_var(TensorX conv_w, TensorX scale, 
                                             TensorX var, bool isSrcOp = true);
+  OpX* create_fuse_conv_batchnorm_bias(TensorX scale,
+                                           TensorX bias, TensorX mean,
+                                           TensorX var, bool isSrcOp = true);
+  OpX* create_broadcast_add(TensorX data, TensorX bias, bool isSrcOp = true);
   OpX* create_pool2d_avg(TensorX input, TensorX weight,
                          //int kernelH, int kernelW,
                          int strideH, int strideW,

--- a/python/taso/__init__.py
+++ b/python/taso/__init__.py
@@ -786,6 +786,7 @@ input_weight_names['Conv'] = ['input', 'weight', 'bias']
 input_weight_names['Matmul'] = ['input', 'weight']
 input_weight_names['Mul'] = ['input1', 'input2']
 input_weight_names['Reshpe'] = ['input', 'shape']
+input_weight_names['BroadcastAdd'] = ['input1', 'input2']
 
 operator_attrs = dict()
 operator_attrs['Add'] = []
@@ -819,6 +820,7 @@ operator_attrs['Reshape'] = []
 operator_attrs['Tanh'] = []
 operator_attrs['Transpose'] = ['perm']
 operator_attrs['Unsqueeze'] = ['axes']
+operator_attrs['BroadcastAdd'] = []
 
 def _input_tensor_name(graph, inedge, op):
     intype = graph.get_operator_type(inedge['srcOp'])

--- a/python/taso/_cython/CCore.pxd
+++ b/python/taso/_cython/CCore.pxd
@@ -93,6 +93,9 @@ cdef extern from "taso/ops.h" namespace "taso":
         OP_RESIZE,
         OP_PRELU,
         OP_FUSE_CONV_BATCHNORM,
+        OP_FUSE_CONV_BATCHNORM_ALPHA_VAR,
+        OP_FUSE_CONV_BATCHNORM_BIAS,
+        OP_BROADCAST_ADD
 
     # This must be consistent with include/taso/ops.h
     cdef enum PMParameter:

--- a/python/taso/_cython/core.pyx
+++ b/python/taso/_cython/core.pyx
@@ -150,6 +150,8 @@ op_table[OP_LOGICAL_NOT] = "Not"
 op_table[OP_SQRT] = "Sqrt"
 op_table[OP_SLICE] = "Slice"
 op_table[OP_RESIZE] = "Resize"
+# op_table[OP_BROADCAST_ADD] = "BroadcastAdd"
+op_table[OP_BROADCAST_ADD] = "Add"
 
 cdef class PyGraph:
     cdef Graph *p_graph #Hold a Graph instance

--- a/src/core/broadcast_add.cc
+++ b/src/core/broadcast_add.cc
@@ -1,0 +1,88 @@
+/* Copyright 2020 Stanford
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "taso/ops.h"
+using namespace taso;
+
+TensorHandle Graph::broadcast_add(const TensorHandle _data,
+                                        const TensorHandle _bias)
+{
+  Op op = model->get_or_create_broadcast_add(*_data, *_bias);
+  add_edge(_data->op, op, _data->idx, 0);
+  add_edge(_bias->op, op, _bias->idx, 1);
+  TensorHandle t = new Tensor(op.ptr->outputs[0]);
+  t->op = op;
+  return t;
+}
+
+Op Model::get_or_create_broadcast_add(const Tensor& _data, const Tensor& _bias)
+{
+  BroadcastAddKey key(_data);
+  BroadcastAdd* newop;
+  if (broadcast_add.find(key) != broadcast_add.end()) {
+    newop = broadcast_add[key];
+  } else {
+    newop = new BroadcastAdd(this, _data, _bias);
+    //Assign a zero cost since it can be preprocessed
+    // measure_fuse_conv_batchnorm_cost(fuseOp);
+    newop->runtime = 0.0f;
+    broadcast_add[key] = newop;
+  }
+  Op ret;
+  ret.guid = global_unique_id ++;
+  ret.ptr = newop;
+  return ret;
+}
+
+BroadcastAdd::BroadcastAdd(Model* _model, const Tensor& _data, const Tensor& _bias)
+: OpBase(_data, _bias, _model, OP_BROADCAST_ADD)
+{
+  assert(_data.numDim == 4);
+  assert(_bias.numDim == 1);
+  numOutputs = 1;
+  outputs[0] = _data;
+  outputs[0].idx = 0;
+}
+
+BroadcastAdd::~BroadcastAdd(void)
+{}
+
+bool BroadcastAdd::get_int_parameter(PMParameter para, int* value)
+{
+  return OpBase::get_int_parameter(para, value);
+}
+
+void BroadcastAdd::collect_costs(float& exe_time, float& flops,
+                                      float& mem_acc, int& num_kernels)
+{
+  // cost metrics
+  exe_time += runtime;
+  flops += outputs[0].volume();
+  mem_acc += outputs[0].volume() * 2;
+  num_kernels += 1;
+  printf("        cost[BroadcastAdd]: i(%d %d %d %d) cost(%.4lf) total_cost(%.4lf)\n",
+          inputs[0].dim[0], inputs[0].dim[1], inputs[0].dim[2], inputs[0].dim[3],
+          runtime, exe_time);
+}
+
+// key is (_conv_w)
+BroadcastAddKey::BroadcastAddKey(const Tensor& _data)
+{
+  int idx = 0;
+  _data.serialize(keys, idx);
+  while (idx < KEY_LENGTH)
+    keys[idx++] = 0;
+  assert(KEY_LENGTH == idx);
+}

--- a/src/core/fuse_conv_batchnorm_alpha_var.cc
+++ b/src/core/fuse_conv_batchnorm_alpha_var.cc
@@ -1,0 +1,96 @@
+/* Copyright 2020 Stanford
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "taso/ops.h"
+using namespace taso;
+
+// // Preproccessing weights to merge conv and batchnorm
+// TensorHandle Graph::fuse_conv_batchnorm_alpha_var(const TensorHandle _conv_w,
+//                                         const TensorHandle _scale,
+//                                         const TensorHandle _var)
+// {
+//   Op op = model->get_or_create_fuse_conv_batchnorm_alpha_var(
+//       *_conv_w, *_scale, *_var);
+//   add_edge(_conv_w->op, op, _conv_w->idx, 0);
+//   add_edge(_scale->op, op, _scale->idx, 1);
+//   add_edge(_var->op, op, _var->idx, 2);
+//   TensorHandle t = new Tensor(op.ptr->outputs[0]);
+//   t->op = op;
+//   return t;
+// }
+
+Op Model::get_or_create_fuse_conv_batchnorm_alpha_var(const Tensor& _conv_w,
+                                            const Tensor& _scale,
+                                            const Tensor& _var)
+{
+  FuseConvBatchNormAlphaVarKey key(_conv_w);
+  FuseConvBatchNormAlphaVar* fuseOp;
+  if (fuse_conv_batchnorm_alpha_var.find(key) != fuse_conv_batchnorm_alpha_var.end()) {
+    fuseOp = fuse_conv_batchnorm_alpha_var[key];
+  } else {
+    fuseOp = new FuseConvBatchNormAlphaVar(this, _conv_w, _scale, _var);
+    //Assign a zero cost since it can be preprocessed
+    // measure_fuse_conv_batchnorm_cost(fuseOp);
+    fuseOp->runtime = 0.0f;
+    fuse_conv_batchnorm_alpha_var[key] = fuseOp;
+  }
+  Op ret;
+  ret.guid = global_unique_id ++;
+  ret.ptr = fuseOp;
+  return ret;
+}
+
+FuseConvBatchNormAlphaVar::FuseConvBatchNormAlphaVar(Model* _model,
+                                     const Tensor& _conv_w,
+                                     const Tensor& _scale,
+                                     const Tensor& _var)
+: OpBase(_conv_w, _scale, _var, _model, OP_FUSE_CONV_BATCHNORM_ALPHA_VAR)
+{
+  assert(_conv_w.numDim == 4);
+  numOutputs = 1;
+  outputs[0] = _conv_w;
+  outputs[0].idx = 0;
+}
+
+FuseConvBatchNormAlphaVar::~FuseConvBatchNormAlphaVar(void)
+{}
+
+bool FuseConvBatchNormAlphaVar::get_int_parameter(PMParameter para, int* value)
+{
+  return OpBase::get_int_parameter(para, value);
+}
+
+void FuseConvBatchNormAlphaVar::collect_costs(float& exe_time, float& flops,
+                                      float& mem_acc, int& num_kernels)
+{
+  // cost metrics
+  exe_time += runtime;
+  flops += outputs[0].volume();
+  mem_acc += outputs[0].volume() * 2;
+  num_kernels += 1;
+  printf("        cost[FuseConvBatchNormAlphaVar]: i(%d %d %d %d) cost(%.4lf) total_cost(%.4lf)\n",
+          inputs[0].dim[0], inputs[0].dim[1], inputs[0].dim[2], inputs[0].dim[3],
+          runtime, exe_time);
+}
+
+// key is (_conv_w)
+FuseConvBatchNormAlphaVarKey::FuseConvBatchNormAlphaVarKey(const Tensor& _conv_w)
+{
+  int idx = 0;
+  _conv_w.serialize(keys, idx);
+  while (idx < KEY_LENGTH)
+    keys[idx++] = 0;
+  assert(KEY_LENGTH == idx);
+}

--- a/src/core/fuse_conv_batchnorm_bias.cc
+++ b/src/core/fuse_conv_batchnorm_bias.cc
@@ -1,0 +1,100 @@
+/* Copyright 2020 Stanford
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "taso/ops.h"
+using namespace taso;
+
+// Preproccessing weights to merge conv and batchnorm
+TensorHandle Graph::fuse_conv_batchnorm_bias(const TensorHandle _scale,
+                                        const TensorHandle _bias,
+                                        const TensorHandle _mean,
+                                        const TensorHandle _var)
+{
+  Op op = model->get_or_create_fuse_conv_batchnorm_bias(
+      *_scale, *_bias, *_mean, *_var);
+  add_edge(_scale->op, op, _scale->idx, 0);
+  add_edge(_bias->op, op, _bias->idx, 1);
+  add_edge(_mean->op, op, _mean->idx, 2);
+  add_edge(_var->op, op, _var->idx, 3);
+  TensorHandle t = new Tensor(op.ptr->outputs[0]);
+  t->op = op;
+  return t;
+}
+
+Op Model::get_or_create_fuse_conv_batchnorm_bias(const Tensor& _scale,
+                                            const Tensor& _bias,
+                                            const Tensor& _mean,
+                                            const Tensor& _var)
+{
+  FuseConvBatchNormBiasKey key(_scale); // to do
+  FuseConvBatchNormBias* fuseOp;
+  if (fuse_conv_batchnorm_bias.find(key) != fuse_conv_batchnorm_bias.end()) {
+    fuseOp = fuse_conv_batchnorm_bias[key];
+  } else {
+    fuseOp = new FuseConvBatchNormBias(this, _scale, _bias, _mean, _var);
+    //Assign a zero cost since it can be preprocessed
+    // measure_fuse_conv_batchnorm_cost(fuseOp);
+    fuseOp->runtime = 0.0f;
+    fuse_conv_batchnorm_bias[key] = fuseOp;
+  }
+  Op ret;
+  ret.guid = global_unique_id ++;
+  ret.ptr = fuseOp;
+  return ret;
+}
+
+FuseConvBatchNormBias::FuseConvBatchNormBias(Model* _model,
+                                     const Tensor& _scale,
+                                     const Tensor& _bias,
+                                     const Tensor& _mean,
+                                     const Tensor& _var)
+: OpBase(_scale, _bias, _mean, _var, _model, OP_FUSE_CONV_BATCHNORM_BIAS)
+{
+  assert(_scale.numDim == 1);
+  numOutputs = 1;
+  outputs[0] = _scale;
+  outputs[0].idx = 0;
+}
+
+FuseConvBatchNormBias::~FuseConvBatchNormBias(void)
+{}
+
+bool FuseConvBatchNormBias::get_int_parameter(PMParameter para, int* value)
+{
+  return OpBase::get_int_parameter(para, value);
+}
+
+void FuseConvBatchNormBias::collect_costs(float& exe_time, float& flops,
+                                      float& mem_acc, int& num_kernels)
+{
+  // cost metrics
+  exe_time += runtime;
+  flops += outputs[0].volume();
+  mem_acc += outputs[0].volume() * 2;
+  num_kernels += 1;
+  printf("        cost[FuseConvBatchNormBias]: i(%d) cost(%.4lf) total_cost(%.4lf)\n",
+          inputs[0].dim[0],
+          runtime, exe_time);
+}
+
+// key is (_conv_w)
+FuseConvBatchNormBiasKey::FuseConvBatchNormBiasKey(const Tensor& _scale)
+{
+  int idx = 0;
+  _scale.serialize(keys, idx);
+  while (idx < KEY_LENGTH)
+    keys[idx++] = 0;
+  assert(KEY_LENGTH == idx);
+}

--- a/src/core/ops.cc
+++ b/src/core/ops.cc
@@ -741,6 +741,8 @@ void Graph::replace_node(Op oldOp, Op newOp)
   for (size_t i = 0; i < outList.size(); i++) {
     Edge e = outList[i];
     remove_edge(e);
+    // update input ptr of dstOp to newOp.output
+    e.dstOp.ptr->inputs[e.dstIdx] = newOp.ptr->outputs[e.srcIdx];
     add_edge(newOp, e.dstOp, e.srcIdx, e.dstIdx);
   }
 }
@@ -1009,7 +1011,7 @@ void Graph::print(void)
   std::map<Op, std::set<Edge, EdgeCompare>, OpCompare>::const_iterator it;
   for (it = inEdges.begin(); it != inEdges.end(); it++) {
     if (it->first.guid == 0) continue;
-    printf("	guid(%zu) type(%d) runtime(%.4lf): ", it->first.guid, it->first.ptr->type, it->first.ptr->runtime);
+    printf("	guid(%zu) type(%d) runtime(%.4lf): ", it->first.guid, it->first.ptr->type, it->first.ptr->runtime);    
     std::set<Edge, EdgeCompare> list = it->second;
     std::set<Edge, EdgeCompare>::const_iterator it2;
     for (it2 = list.begin(); it2 != list.end(); it2++) {
@@ -1017,6 +1019,9 @@ void Graph::print(void)
       printf(" inEdge(guid(%zu) idx(%d))", e.srcOp.guid, e.srcIdx);
     }
     printf("\n");
+    if (it->first.ptr->type==3) {
+      it->first.ptr->inputs[1].print_info("conv weight");
+    }
   }
 }
 
@@ -1334,8 +1339,9 @@ void Graph::print_costs(void)
   float exe_time = 0, flops = 0, mem_acc = 0;
   int num_kernels = 0;
   std::map<Op, std::set<Edge, EdgeCompare>, OpCompare>::const_iterator it;
-  for (it = inEdges.begin(); it != inEdges.end(); it++)
+  for (it = inEdges.begin(); it != inEdges.end(); it++) {
     it->first.ptr->collect_costs(exe_time, flops, mem_acc, num_kernels);
+  }
   printf("        Cost metrics: exe_time(%.4lf) flops(%.4lf) "
          "memory_access(%.4lf) kernel_launches(%d)\n",
          exe_time, flops / 1024.0 / 1024.0 / 1024.0,

--- a/src/core/ops.cc
+++ b/src/core/ops.cc
@@ -125,6 +125,25 @@ OpBase::OpBase(const Tensor& _input0,
                const Tensor& _input1,
                const Tensor& _input2,
                const Tensor& _input3,
+               Model* _model, OpType _type)
+: numInputs(5), model(_model), type(_type), runtime(0.0f)
+{
+  inputs[0] = _input0;
+  inputs[1] = _input1;
+  inputs[2] = _input2;
+  inputs[3] = _input3;
+  for (int i = 0; i < MAX_NUM_OUTPUTS; i++) {
+    outputs[i].numDim = 0;
+    for (int j = 0; j < MAX_DIM; j++)
+      outputs[i].dim[j] = 0;
+  }
+}
+
+
+OpBase::OpBase(const Tensor& _input0,
+               const Tensor& _input1,
+               const Tensor& _input2,
+               const Tensor& _input3,
                const Tensor& _input4,
                Model* _model, OpType _type)
 : numInputs(5), model(_model), type(_type), runtime(0.0f)
@@ -1019,9 +1038,18 @@ void Graph::print(void)
       printf(" inEdge(guid(%zu) idx(%d))", e.srcOp.guid, e.srcIdx);
     }
     printf("\n");
-    if (it->first.ptr->type==3) {
-      it->first.ptr->inputs[1].print_info("conv weight");
-    }
+    // if (it->first.ptr->type == OP_CONV2D) {
+    //   it->first.ptr->inputs[1].print_info("conv weight");
+    // }
+    // else if (it->first.ptr->type == OP_BROADCAST_ADD) {
+    //   it->first.ptr->inputs[1].print_info("conv new bias");
+    // }
+    // else if (it->first.ptr->type == OP_BATCHNORM) {
+    //   it->first.ptr->inputs[1].print_info("gamma");
+    //   it->first.ptr->inputs[2].print_info("beta");
+    //   it->first.ptr->inputs[3].print_info("mean");
+    //   it->first.ptr->inputs[4].print_info("var");
+    // }
   }
 }
 

--- a/src/core/substitution.cc
+++ b/src/core/substitution.cc
@@ -89,11 +89,15 @@ GraphXfer* GraphXfer::create_conv_batch(Model* model, int strideH, int strideW, 
   OpX* fuse = subst->create_fuse_conv_batchnorm_alpha_var(weight, w[0], w[3], false/*isSrc*/); // alpha, var
   OpX* new_conv = subst->create_conv2d(input, fuse->outputs[0], strideH, strideW, mode,
                                        AC_MODE_NONE, false/*isSrc*/);
-  subst->map_output(batch->outputs[0], new_conv->outputs[0]);
+  OpX* bias = subst->create_fuse_conv_batchnorm_bias(w[0], w[1], w[2], w[3], false);
+  OpX* add = subst->create_broadcast_add(new_conv->outputs[0], bias->outputs[0], false);
+  subst->map_output(batch->outputs[0], add->outputs[0]);
   subst->srcOps.push_back(conv);
   subst->srcOps.push_back(batch);
   subst->dstOps.push_back(fuse);
   subst->dstOps.push_back(new_conv);
+  subst->dstOps.push_back(bias);
+  subst->dstOps.push_back(add);
   return subst;
 }
 
@@ -497,6 +501,7 @@ OpX::OpX(OpType _type, TensorX in1, TensorX in2)
     case OP_MATMUL:
     case OP_MUL:
     case OP_ENLARGE:
+    case OP_BROADCAST_ADD:
       outputs.push_back(out);
       break;
     default:
@@ -513,6 +518,22 @@ OpX::OpX(OpType _type, TensorX in1, TensorX in2, TensorX in3)
   TensorX out(this, 0);
   switch (type) {
     case OP_FUSE_CONV_BATCHNORM_ALPHA_VAR:
+      outputs.push_back(out);
+      break;
+    default:
+      assert(false);
+  }
+}
+OpX::OpX(OpType _type, TensorX in1, TensorX in2, TensorX in3, TensorX in4)
+: type(_type)
+{
+  inputs.push_back(in1);
+  inputs.push_back(in2);
+  inputs.push_back(in3);
+  inputs.push_back(in4);
+  TensorX out(this, 0);
+  switch (type) {
+    case OP_FUSE_CONV_BATCHNORM_BIAS:
       outputs.push_back(out);
       break;
     default:
@@ -698,6 +719,21 @@ OpX* GraphXfer::create_fuse_conv_batchnorm_alpha_var(TensorX conv_w, TensorX sca
   OpX* fuse = new OpX(OP_FUSE_CONV_BATCHNORM_ALPHA_VAR, conv_w, scale, var);
   return fuse;
 }
+
+OpX* GraphXfer::create_fuse_conv_batchnorm_bias(TensorX scale,
+                                           TensorX bias, TensorX mean,
+                                           TensorX var, bool isSrcOp)
+{
+  OpX* fuse = new OpX(OP_FUSE_CONV_BATCHNORM_BIAS, scale, bias, mean, var);
+  return fuse;
+}
+
+OpX* GraphXfer::create_broadcast_add(TensorX data, TensorX bias, bool isSrcOp)
+{
+  OpX* fuse = new OpX(OP_BROADCAST_ADD, data, bias);
+  return fuse;
+}
+
 
 OpX* GraphXfer::create_pool2d_avg(TensorX input, TensorX weight,
                                   int strideH, int strideW,
@@ -1210,6 +1246,16 @@ bool GraphXfer::create_new_operator(const OpX* opx, Op& op)
       op = model->get_or_create_fuse_conv_batchnorm(conv_w, scale, bias, mean, var);
       break;
     }
+    case OP_FUSE_CONV_BATCHNORM_BIAS:
+    {
+      assert(opx->inputs.size() == 4);
+      Tensor scale = opx->inputs[0].to_tensor(this);
+      Tensor bias = opx->inputs[1].to_tensor(this);
+      Tensor mean = opx->inputs[2].to_tensor(this);
+      Tensor var = opx->inputs[3].to_tensor(this);
+      op = model->get_or_create_fuse_conv_batchnorm_bias(scale, bias, mean, var);
+      break;
+    }
     case OP_FUSE_CONV_BATCHNORM_ALPHA_VAR:
     {
       assert(opx->inputs.size() == 3);
@@ -1217,6 +1263,14 @@ bool GraphXfer::create_new_operator(const OpX* opx, Op& op)
       Tensor scale = opx->inputs[1].to_tensor(this);
       Tensor var = opx->inputs[2].to_tensor(this);
       op = model->get_or_create_fuse_conv_batchnorm_alpha_var(conv_w, scale, var);
+      break;
+    }
+    case OP_BROADCAST_ADD:
+    {
+      assert(opx->inputs.size() == 2);
+      Tensor _data = opx->inputs[0].to_tensor(this);
+      Tensor _bias = opx->inputs[1].to_tensor(this);
+      op = model->get_or_create_broadcast_add(_data, _bias);
       break;
     }
     case OP_MATMUL:

--- a/src/cudnn/broadcast_add_kernel.cu
+++ b/src/cudnn/broadcast_add_kernel.cu
@@ -1,0 +1,63 @@
+/* Copyright 2020 Stanford
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "taso/ops.h"
+#include "taso/cuda_helper.h"
+using namespace taso;
+
+__global__
+void broadcast_add_kernel(int batch,
+                          int channel,
+                          int h_w_size,
+                          DATATYPE* dst_ptr,
+                          DATATYPE* _data,
+                          DATATYPE* _bias)
+{
+  int volume = batch * channel * h_w_size;
+  CUDA_KERNEL_LOOP(i, volume)
+  {
+    int channel_idx = i % h_w_size;
+    dst_ptr[i] = _data[i] + _bias[channel_idx];
+  }
+}
+
+void BroadcastAdd::map(void)
+{
+  assert(inputs[0].numDim == 4);
+  assert(inputs[1].numDim == 1);
+  size_t outputSize = sizeof(DATATYPE) * outputs[0].volume();
+  checkCUDA(cudaMalloc(&outputs[0].data_ptr, outputSize));
+}
+
+void BroadcastAdd::unmap(void)
+{
+  checkCUDA(cudaFree(outputs[0].data_ptr));
+}
+
+void BroadcastAdd::forward(bool block)
+{
+  int batch = outputs[0].dim[0];
+  int channel = outputs[0].dim[1];
+  int h_w_size = outputs[0].dim[2] * outputs[0].dim[3];
+  DATATYPE* _data_ptr = (DATATYPE*) inputs[0].data_ptr;
+  DATATYPE* _bias_ptr = (DATATYPE*) inputs[1].data_ptr;
+  broadcast_add_kernel<<<GET_BLOCKS(outputs[0].volume()), CUDA_NUM_THREADS>>>(
+      batch, channel, h_w_size, (DATATYPE*)outputs[0].data_ptr,
+      _data_ptr, _bias_ptr);
+  if (block)
+    checkCUDA(cudaDeviceSynchronize());
+}
+
+

--- a/src/cudnn/fuse_conv_batchnorm_alpha_var_kernel.cu
+++ b/src/cudnn/fuse_conv_batchnorm_alpha_var_kernel.cu
@@ -36,6 +36,8 @@ void fuse_conv_batchnorm_alpha_var_kernel(int c_out,
 void FuseConvBatchNormAlphaVar::map(void)
 {
   assert(inputs[0].numDim == 4);
+  assert(inputs[1].numDim == 1);
+  assert(inputs[2].numDim == 1);
   size_t outputSize = sizeof(DATATYPE) * outputs[0].volume();
   checkCUDA(cudaMalloc(&outputs[0].data_ptr, outputSize));
 }

--- a/src/cudnn/fuse_conv_batchnorm_alpha_var_kernel.cu
+++ b/src/cudnn/fuse_conv_batchnorm_alpha_var_kernel.cu
@@ -1,0 +1,62 @@
+/* Copyright 2020 Stanford
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "taso/ops.h"
+#include "taso/cuda_helper.h"
+using namespace taso;
+
+__global__
+void fuse_conv_batchnorm_alpha_var_kernel(int c_out,
+                                int c_in_h_w,
+                                DATATYPE* dst_ptr,
+                                DATATYPE* conv_w,
+                                DATATYPE* scale,
+                                DATATYPE* var)
+{
+  int volume = c_out * c_in_h_w;
+  CUDA_KERNEL_LOOP(i, volume)
+  {
+    int c_out_idx = i / c_in_h_w;
+    dst_ptr[i] = scale[c_out_idx] * conv_w[i] / sqrt(abs(var[c_out_idx]) + CUDNN_BN_MIN_EPSILON);
+  }
+}
+
+void FuseConvBatchNormAlphaVar::map(void)
+{
+  assert(inputs[0].numDim == 4);
+  size_t outputSize = sizeof(DATATYPE) * outputs[0].volume();
+  checkCUDA(cudaMalloc(&outputs[0].data_ptr, outputSize));
+}
+
+void FuseConvBatchNormAlphaVar::unmap(void)
+{
+  checkCUDA(cudaFree(outputs[0].data_ptr));
+}
+
+void FuseConvBatchNormAlphaVar::forward(bool block)
+{
+  int c_out = outputs[0].dim[0];
+  int c_in_h_w = outputs[0].volume() / c_out;
+  DATATYPE* conv_w_ptr = (DATATYPE*) inputs[0].data_ptr;
+  DATATYPE* scale_ptr = (DATATYPE*) inputs[1].data_ptr;
+  DATATYPE* var_ptr = (DATATYPE*) inputs[2].data_ptr;
+  fuse_conv_batchnorm_alpha_var_kernel<<<GET_BLOCKS(outputs[0].volume()), CUDA_NUM_THREADS>>>(
+      c_out, c_in_h_w, (DATATYPE*)outputs[0].data_ptr,
+      conv_w_ptr, scale_ptr, var_ptr);
+  if (block)
+    checkCUDA(cudaDeviceSynchronize());
+}
+
+

--- a/src/cudnn/fuse_conv_batchnorm_kernel.cu
+++ b/src/cudnn/fuse_conv_batchnorm_kernel.cu
@@ -29,7 +29,7 @@ void fuse_conv_batchnorm_kernel(int c_out,
   CUDA_KERNEL_LOOP(i, volume)
   {
     int c_out_idx = i / c_in_h_w;
-    dst_ptr[i] = scale[c_out_idx] * conv_w[i] / sqrt(abs(var[i]) + CUDNN_BN_MIN_EPSILON);
+    dst_ptr[i] = scale[c_out_idx] * conv_w[i] / sqrt(abs(var[c_out_idx]) + CUDNN_BN_MIN_EPSILON);
   }
 }
 

--- a/src/cudnn/fuse_conv_batchnorm_kernel_alpha_var.cu
+++ b/src/cudnn/fuse_conv_batchnorm_kernel_alpha_var.cu
@@ -1,0 +1,62 @@
+/* Copyright 2020 Stanford
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "taso/ops.h"
+#include "taso/cuda_helper.h"
+using namespace taso;
+
+__global__
+void fuse_conv_batchnorm_alpha_var_kernel(int c_out,
+                                int c_in_h_w,
+                                DATATYPE* dst_ptr,
+                                DATATYPE* conv_w,
+                                DATATYPE* scale,
+                                DATATYPE* var)
+{
+  int volume = c_out * c_in_h_w;
+  CUDA_KERNEL_LOOP(i, volume)
+  {
+    int c_out_idx = i / c_in_h_w;
+    dst_ptr[i] = scale[c_out_idx] * conv_w[i] / sqrt(abs(var[c_out_idx]) + CUDNN_BN_MIN_EPSILON);
+  }
+}
+
+void FuseConvBatchNormAlphaVar::map(void)
+{
+  assert(inputs[0].numDim == 4);
+  size_t outputSize = sizeof(DATATYPE) * outputs[0].volume();
+  checkCUDA(cudaMalloc(&outputs[0].data_ptr, outputSize));
+}
+
+void FuseConvBatchNormAlphaVar::unmap(void)
+{
+  checkCUDA(cudaFree(outputs[0].data_ptr));
+}
+
+void FuseConvBatchNormAlphaVar::forward(bool block)
+{
+  int c_out = outputs[0].dim[0];
+  int c_in_h_w = outputs[0].volume() / c_out;
+  DATATYPE* conv_w_ptr = (DATATYPE*) inputs[0].data_ptr;
+  DATATYPE* scale_ptr = (DATATYPE*) inputs[1].data_ptr;
+  DATATYPE* var_ptr = (DATATYPE*) inputs[2].data_ptr;
+  fuse_conv_batchnorm_alpha_var_kernel<<<GET_BLOCKS(outputs[0].volume()), CUDA_NUM_THREADS>>>(
+      c_out, c_in_h_w, (DATATYPE*)outputs[0].data_ptr,
+      conv_w_ptr, scale_ptr, var_ptr);
+  if (block)
+    checkCUDA(cudaDeviceSynchronize());
+}
+
+


### PR DESCRIPTION
- fix bug in `fuse_conv_batchnorm_kernel` and `replace_node`;
- current `fuse_conv_batchnorm` only fuse gamma/sqrt(var+eps) with weight. ignore the bias `beta - gamma*mean/sqrt(var + eps)`. the complete implementation as below:
```shell
1. fuse coeifficient to weight
2. do conv with new weight;
3. get bias with `beta - gamma*mean/sqrt(var + eps)`
4. broadcast add between conv.output and bias
```
- the parameter of `alpha, beta` in `batchnorm_kernel.cu/cudnnBatchNormalizationForwardInference`  seems like wrong.
according to [cudnn doc](https://docs.nvidia.com/deeplearning/sdk/cudnn-archived/cudnn_701/cudnn-user-guide/index.html#cudnnBatchNormalizationForwardInference) , `alpha should be 0, beta should be 1`. in this setting `cudnnBatchNormalizationForwardInference` is equal to `bnScale * (x-estimatedMean)/sqrt(epsilon + estimatedVariance)+bnBias`. But current setting is `alpha=1, beta=0`, which means `identity`.

