### PR TITLE
Bug fixes to correct import and export of ONNX models

### DIFF
--- a/python/taso/__init__.py
+++ b/python/taso/__init__.py
@@ -242,12 +242,24 @@ def _exp(op, graph, tensors, initializer):
     outputs = graph.exp(input=inputs[0])
     return outputs
 
+def _flatten(op, graph, tensors, initializer):
+    inputs = _get_inputs(op, graph, tensors, initializer)
+    assert len(inputs) == 1, "Flatten requires exactly one input"
+    shape = []
+    shape.append(inputs[0].dim(0))
+    dim = 1
+    for i in range(1, inputs[0].nDim):
+        dim *= inputs[0].dim(i)
+    shape.append(dim)
+    outputs = graph.reshape(inputs[0], tuple(shape))
+    return outputs
+
 def _gemm(op, graph, tensors, initializer):
     inputs = _get_inputs(op, graph, tensors, initializer)
     attrs = _parse_attribute(op.attribute)
-    if "transA" in attrs:
+    if "transA" in attrs and attrs["transA"] == 1:
         inputs[0] = graph.transpose(inputs[0], (1,0), shuffle=True)
-    if "transB" in attrs:
+    if "transB" in attrs and attrs["transB"] == 1:
         inputs[1] = graph.transpose(inputs[1], (1,0), shuffle=True)
     outputs = graph.matmul(inputs[0], inputs[1])
     return outputs
@@ -304,7 +316,7 @@ def _logical_not(op, graph, tensors, initializer):
 
 def _matmul(op, graph, tensors, initializer):
     inputs = _get_inputs(op, graph, tensors, initializer)
-    assert len(inputs) == 2, "Matmul takes exactly two inputs"
+    assert len(inputs) == 2, "MatMul takes exactly two inputs"
     outputs = graph.matmul(inputs[0], inputs[1])
     return outputs
 
@@ -359,6 +371,16 @@ def _avgpool2d(op, graph, tensors, initializer):
     kernels = attrs["kernel_shape"]
     strides = attrs["strides"]
     pads = _get_conv_pool_pads_attr(attrs)
+    outputs = graph.avgpool2d(input=inputs[0], kernels=kernels, strides=strides, padding=pads)
+    return outputs
+
+def _globalavgpool2d(op, graph, tensors, initializer):
+    inputs = _get_inputs(op, graph, tensors, initializer)
+    assert len(inputs) == 1, "GlobalAvgPool2D requires exactly one input"
+    dim = inputs[0].dim(inputs[0].nDim-1)
+    kernels = [dim, dim]
+    strides = [1, 1]
+    pads = "VALID"
     outputs = graph.avgpool2d(input=inputs[0], kernels=kernels, strides=strides, padding=pads)
     return outputs
 
@@ -648,6 +670,7 @@ xf_operators['Div'] = _div
 xf_operators['Dropout'] = _dropout
 xf_operators['Equal'] = _equal
 xf_operators['Exp'] = _exp
+xf_operators['Flatten'] = _flatten
 xf_operators['Gemm'] = _gemm
 xf_operators['Greater'] = _greater
 xf_operators['Identity'] = _identity
@@ -664,13 +687,14 @@ xf_operators['ReduceSum'] = _reducesum
 xf_operators['Reshape'] = _reshape
 xf_operators['Relu'] = _relu
 xf_operators['Round'] = _round
-xf_operators['Matmul'] = _matmul
+xf_operators['MatMul'] = _matmul
 xf_operators['Max'] = _max
 xf_operators['MaxPool'] = _maxpool2d
 xf_operators['Min'] = _min
 xf_operators['Mul'] = _mul
 xf_operators['Not'] = _logical_not
 xf_operators['AveragePool'] = _avgpool2d
+xf_operators['GlobalAveragePool'] = _globalavgpool2d
 xf_operators['Shape'] = _shape
 xf_operators['Size'] = _size
 xf_operators['Slice'] = _slice
@@ -760,7 +784,7 @@ def load_onnx(filename):
         idx += 1
     assert len(node_list) == len(model.graph.node), "Internal error when reording ONNX operators"
 
-    # Add nodse into TASO graph
+    # Add nodes into TASO graph
     cnt = 0
     for opname in node_list:
         op = name_to_op[opname]
@@ -789,10 +813,11 @@ input_weight_names['AveragePool'] = ['input']
 input_weight_names['BatchNormalization'] = ['input', 'scale', 'bias', 'mean', 'var']
 input_weight_names['Concat'] = ['input1', 'input2', 'input3', 'input4', 'input5', 'input6']
 input_weight_names['Conv'] = ['input', 'weight', 'bias']
-input_weight_names['Matmul'] = ['input', 'weight']
+input_weight_names['MatMul'] = ['input', 'weight']
 input_weight_names['Mul'] = ['input1', 'input2']
-input_weight_names['Reshpe'] = ['input', 'shape']
+input_weight_names['Reshape'] = ['input', 'shape']
 input_weight_names['BroadcastAdd'] = ['input1', 'input2']
+input_weight_names['Transpose'] = ['input']
 
 operator_attrs = dict()
 operator_attrs['Add'] = []
@@ -812,7 +837,7 @@ operator_attrs['Identity'] = []
 operator_attrs['Less'] = []
 operator_attrs['Log'] = []
 operator_attrs['Pad'] = []
-operator_attrs['Matmul'] = []
+operator_attrs['MatMul'] = []
 operator_attrs['MaxPool'] = ['kernel_shape', 'pads', 'strides']
 operator_attrs['Mul'] = []
 operator_attrs['Shape'] = []

--- a/python/taso/__init__.py
+++ b/python/taso/__init__.py
@@ -213,6 +213,10 @@ def _conv2d(op, graph, tensors, initializer):
     pads = _get_conv_pool_pads_attr(attrs)
     strides = attrs["strides"]
     outputs = graph.conv2d(input=inputs[0], weight=inputs[1], strides=strides, padding=pads)
+    if len(inputs) > 2:
+        dim = inputs[2].dim(0)
+        reshaped_bias = graph.reshape(inputs[2], (1, dim, 1, 1))
+        outputs = graph.add(outputs, reshaped_bias)
     return outputs
 
 def _div(op, graph, tensors, initializer):
@@ -262,6 +266,8 @@ def _gemm(op, graph, tensors, initializer):
     if "transB" in attrs and attrs["transB"] == 1:
         inputs[1] = graph.transpose(inputs[1], (1,0), shuffle=True)
     outputs = graph.matmul(inputs[0], inputs[1])
+    if len(inputs) > 2:
+        outputs = graph.add(outputs, inputs[2])
     return outputs
 
 def _greater(op, graph, tensors, initializer):

--- a/python/taso/__init__.py
+++ b/python/taso/__init__.py
@@ -155,7 +155,11 @@ def _argmin(op, graph, tensors, initializer):
 def _batchnorm(op, graph, tensors, initializer):
     inputs = _get_inputs(op, graph, tensors, initializer)
     attrs = _parse_attribute(op.attribute)
-    outputs = graph.batchnorm(inputs[0], inputs[1], inputs[2], inputs[3], inputs[4])
+    if 'epsilon' in attrs:
+        epsilon = attrs['epsilon']
+    else:
+        epsilon = -1
+    outputs = graph.batchnorm(inputs[0], inputs[1], inputs[2], inputs[3], inputs[4], epsilon)
     return outputs
 
 def _cast(op, graph, tensors, initializer):
@@ -830,7 +834,7 @@ operator_attrs['Add'] = []
 operator_attrs['ArgMax'] = []
 operator_attrs['ArgMin'] = []
 operator_attrs['AveragePool'] = ['kernel_shape', 'pads', 'strides']
-operator_attrs['BatchNormalization'] = [] # TODO: Add epsilon and momentum
+operator_attrs['BatchNormalization'] = ['epsilon'] # TODO: Add momentum
 operator_attrs['Cast'] = []
 operator_attrs['Ceil'] = []
 operator_attrs['Concat'] = ['axis']

--- a/python/taso/_cython/CCore.pxd
+++ b/python/taso/_cython/CCore.pxd
@@ -115,6 +115,7 @@ cdef extern from "taso/ops.h" namespace "taso":
         PM_OUTSHUFFLE
         PM_MERGE_GCONV_COUNT
         PM_AXES
+        PM_EPSILON
 
     # This must be consistent with include/taso/ops.h
     cdef enum ActiMode:
@@ -175,7 +176,8 @@ cdef extern from "taso/ops.h" namespace "taso":
                                const TensorHandle scale,
                                const TensorHandle bias,
                                const TensorHandle mean,
-                               const TensorHandle var)
+                               const TensorHandle var,
+                               const float epsilon)
         TensorHandle cast(const TensorHandle input, DataType datatype)
         TensorHandle ceil(const TensorHandle input)
         TensorHandle concat(int axis, int n,
@@ -262,6 +264,7 @@ cdef extern from "taso/ops.h" namespace "taso":
         int get_input_edges(Edge* edges, size_t guid)
         OpType get_operator_type(size_t guid)
         int get_operator_int_attr(size_t guid, PMParameter attr)
+        float get_operator_float_attr(size_t guid, PMParameter attr)
         int get_num_outputs(size_t guid)
         int get_input_dims(size_t guid, int* dims, int idx)
         void get_weight_value(size_t guid, float* data)

--- a/python/taso/_cython/core.pyx
+++ b/python/taso/_cython/core.pyx
@@ -190,8 +190,9 @@ cdef class PyGraph:
         t = ctypes.cast(<unsigned long long>handle, ctypes.c_void_p)
         return PyTensor(t)
 
-    def batchnorm(self, PyTensor input, PyTensor scale, PyTensor bias, PyTensor mean, PyTensor var):
-        cdef TensorHandle handle = self.p_graph.batchnorm(input.ctensor, scale.ctensor, bias.ctensor, mean.ctensor, var.ctensor)
+    def batchnorm(self, PyTensor input, PyTensor scale, PyTensor bias, PyTensor mean, PyTensor var, float epsilon = -1):
+        cdef TensorHandle handle = self.p_graph.batchnorm(input.ctensor, scale.ctensor,
+                                                          bias.ctensor, mean.ctensor, var.ctensor, epsilon)
         t = ctypes.cast(<unsigned long long>handle, ctypes.c_void_p)
         return PyTensor(t)
 
@@ -654,6 +655,8 @@ cdef class PyGraph:
                 perIdx = perIdx // len(dims)
             perm = tuple(dims)
             return perm
+        elif attrname == 'epsilon':
+            return self.p_graph.get_operator_float_attr(op.guid, PM_EPSILON)
         elif attrname == 'axes':
             # FIXME
             return [0]

--- a/python/taso/_cython/core.pyx
+++ b/python/taso/_cython/core.pyx
@@ -634,6 +634,11 @@ cdef class PyGraph:
                 padW = max(kw - sw, 0)
             else:
                 padW = max(kw - (inputW % sw), 0)
+            # Ensure padding is same on both sides
+            if padH % 2 == 1:
+                padH += 1
+            if padW % 2 == 1:
+                padW += 1
             return [padH // 2, padW // 2, padH - padH // 2, padW - padW // 2]
         elif attrname == 'group':
             return self.p_graph.get_operator_int_attr(op.guid, PM_GROUP)

--- a/python/taso/_cython/core.pyx
+++ b/python/taso/_cython/core.pyx
@@ -91,6 +91,13 @@ cdef class PyTensor:
         def __set__(self, value):
             self._set_tensor(value)
 
+    property nDim:
+        def __get__(self):
+            if self.ctensor == NULL:
+                return None
+            else:
+                return self.ctensor.numDim
+
     def __cinit__(self, tensor):
         self._set_tensor(tensor)
 
@@ -119,7 +126,7 @@ op_table[OP_RESHAPE] = "Reshape"
 op_table[OP_TRANSPOSE] = "Transpose"
 op_table[OP_EW_ADD] = "Add"
 op_table[OP_EW_MUL] = "Mul"
-op_table[OP_MATMUL] = "Matmul"
+op_table[OP_MATMUL] = "MatMul"
 op_table[OP_SQUEEZE] = "Squeeze"
 op_table[OP_UNSQUEEZE] = "Unsqueeze"
 op_table[OP_EW_SUB] = "Sub"

--- a/src/core/batchnorm.cc
+++ b/src/core/batchnorm.cc
@@ -68,7 +68,7 @@ BatchNorm::BatchNorm(Model* _model,
 : OpBase(_input, _scale, _bias, _mean, _var, _model, OP_BATCHNORM)
 {
   epsilon = _epsilon < 0 ? get_min_epsilon() : _epsilon;
-  assert(_epsilon >= get_min_epsilon());
+  assert(epsilon >= get_min_epsilon());
   assert(_input.numDim == 4);
   numOutputs = 1;
   outputs[0] = _input;

--- a/src/core/batchnorm.cc
+++ b/src/core/batchnorm.cc
@@ -20,10 +20,11 @@ TensorHandle Graph::batchnorm(const TensorHandle _input,
                               const TensorHandle _scale,
                               const TensorHandle _bias,
                               const TensorHandle _mean,
-                              const TensorHandle _var)
+                              const TensorHandle _var,
+                              const float _epsilon)
 {
   Op op = model->get_or_create_batchnorm(*_input, *_scale, *_bias,
-                                         *_mean, *_var);
+                                         *_mean, *_var, _epsilon);
   add_edge(_input->op, op, _input->idx, 0);
   add_edge(_scale->op, op, _scale->idx, 1);
   add_edge(_bias->op, op, _bias->idx, 2);
@@ -38,7 +39,8 @@ Op Model::get_or_create_batchnorm(const Tensor& _input,
                                   const Tensor& _scale,
                                   const Tensor& _bias,
                                   const Tensor& _mean,
-                                  const Tensor& _var)
+                                  const Tensor& _var,
+                                  const float _epsilon)
 {
   // key is (inputN, inputC, inputH, inputW)
   BatchNormKey key(_input);
@@ -46,7 +48,7 @@ Op Model::get_or_create_batchnorm(const Tensor& _input,
   if(batchnorm.find(key) != batchnorm.end()) {
     bnOp = batchnorm[key];
   } else {
-    bnOp = new BatchNorm(this, _input, _scale, _bias, _mean, _var);
+    bnOp = new BatchNorm(this, _input, _scale, _bias, _mean, _var, _epsilon);
     measure_batchnorm_cost(bnOp);
     batchnorm[key] = bnOp;
   }
@@ -61,9 +63,12 @@ BatchNorm::BatchNorm(Model* _model,
                      const Tensor& _scale,
                      const Tensor& _bias,
                      const Tensor& _mean,
-                     const Tensor& _var)
+                     const Tensor& _var,
+                     const float _epsilon)
 : OpBase(_input, _scale, _bias, _mean, _var, _model, OP_BATCHNORM)
 {
+  epsilon = _epsilon < 0 ? get_min_epsilon() : _epsilon;
+  assert(_epsilon >= get_min_epsilon());
   assert(_input.numDim == 4);
   numOutputs = 1;
   outputs[0] = _input;
@@ -76,6 +81,19 @@ BatchNorm::~BatchNorm(void)
 bool BatchNorm::get_int_parameter(PMParameter para, int* value)
 {
   return OpBase::get_int_parameter(para, value);
+}
+
+bool BatchNorm::get_float_parameter(PMParameter para, float* value)
+{
+  switch (para) {
+    case PM_EPSILON:
+    {
+      *value = epsilon;
+      return true;
+    }
+    default:
+      return OpBase::get_float_parameter(para, value);
+  }
 }
 
 void BatchNorm::collect_costs(float& exe_time, float& flops,

--- a/src/core/ops.cc
+++ b/src/core/ops.cc
@@ -190,6 +190,14 @@ bool OpBase::get_int_parameter(PMParameter para, int* value)
   }
 }
 
+bool OpBase::get_float_parameter(PMParameter para, float* value)
+{
+  switch (para) {
+    default:
+      return false;
+  }
+}
+
 bool OpBase::get_input_parameter(TNParameter tnp, DIMParameter dim, int* value)
 {
   int inputIdx = 0, dimIdx = 0;
@@ -681,6 +689,14 @@ int Graph::get_operator_int_attr(size_t guid, PMParameter attr)
   Op op = find_op_or_fail(guid);
   int ret;
   assert(op.ptr->get_int_parameter(attr, &ret));
+  return ret;
+}
+
+float Graph::get_operator_float_attr(size_t guid, PMParameter attr)
+{
+  Op op = find_op_or_fail(guid);
+  float ret;
+  assert(op.ptr->get_float_parameter(attr, &ret));
   return ret;
 }
 
@@ -1307,7 +1323,8 @@ float Graph::run(void)
       case OP_BATCHNORM:
       {
         assert(inList.size() == 5);
-        opPtr = new BatchNorm(model, inputs[0], inputs[1], inputs[2], inputs[3], inputs[4]);
+        BatchNorm* batchnorm = (BatchNorm*) op.ptr;
+        opPtr = new BatchNorm(model, inputs[0], inputs[1], inputs[2], inputs[3], inputs[4], batchnorm->epsilon);
         break;
       }
       case OP_SPLIT:

--- a/src/core/ops.cc
+++ b/src/core/ops.cc
@@ -270,7 +270,7 @@ std::string Op::op_to_string(const OpBase* ptr)
     case OP_EW_MUL:
       return "Mul";
     case OP_MATMUL:
-      return "Matmul";
+      return "MatMul";
     case OP_MUL:
       return "Mul";
     case OP_ENLARGE:
@@ -515,8 +515,16 @@ Graph* Graph::preprocess_weights(void)
   while (true) {
     bool change = false;
     for (opIt = newGraph->inEdges.begin(); opIt != newGraph->inEdges.end(); opIt++) {
-      if (opIt->first.ptr->type == OP_INPUT || opIt->first.ptr->type == OP_WEIGHT)
+      if (opIt->first.ptr->type == OP_INPUT || opIt->first.ptr->type == OP_WEIGHT) {
         continue;
+      } else if (opIt->first.ptr->type == OP_TRANSPOSE) {
+        // NOTE: We skip OP_TRANSPOSE here because the kernel implementation
+        // of OP_TRANSPOSE is currently a no-op, and therefore the correct
+        // output will not be returned. To fix this, we should
+        // implement the cuBLAS transpose operator and/or add an OP_GEMM
+        // to automatically transpose inputs.
+        continue;
+      }
       bool allWeights = true;
       const std::set<Edge, EdgeCompare>& list = opIt->second;
       std::set<Edge, EdgeCompare>::const_iterator it;

--- a/src/cudnn/batchnorm_kernel.cu
+++ b/src/cudnn/batchnorm_kernel.cu
@@ -17,6 +17,11 @@
 #include "taso/cuda_helper.h"
 using namespace taso;
 
+float BatchNorm::get_min_epsilon(void)
+{
+  return CUDNN_BN_MIN_EPSILON;
+}
+
 void BatchNorm::map(void)
 {
   assert(inputs[0].numDim == 4);
@@ -75,6 +80,7 @@ void BatchNorm::forward(bool block)
 {
   const float alpha = 1.0f;
   const float beta = 0.0f;
+  const float eps = epsilon;
   cudnnBatchNormMode_t mode = CUDNN_BATCHNORM_SPATIAL;
   //int inputC = inputs[0].dim[1];
 #ifdef DO_TRAINING 
@@ -86,13 +92,13 @@ void BatchNorm::forward(bool block)
     checkCUDNN(cudnnBatchNormalizationForwardTraining(
       model->dnn, mode, &alpha, &beta, inputTensor, inputs[0].data_ptr,
       outputTensor, outputs[0].data_ptr, biasTensor, scalePtr, biasPtr,
-      1.0, runningMean, runningVar, CUDNN_BN_MIN_EPSILON, saveMean, saveVar));
+      1.0, runningMean, runningVar, eps, saveMean, saveVar));
   } else {
 #endif
     checkCUDNN(cudnnBatchNormalizationForwardInference(
       model->dnn, mode, &alpha, &beta, inputTensor, inputs[0].data_ptr,
       outputTensor, outputs[0].data_ptr, biasTensor, inputs[1].data_ptr, inputs[2].data_ptr,
-      inputs[3].data_ptr, inputs[4].data_ptr, CUDNN_BN_MIN_EPSILON)); 
+      inputs[3].data_ptr, inputs[4].data_ptr, eps));
 #ifdef DO_TRAINING 
   }
 #endif

--- a/src/cudnn/batchnorm_kernel.cu
+++ b/src/cudnn/batchnorm_kernel.cu
@@ -149,8 +149,9 @@ void Model::measure_batchnorm_cost(BatchNorm* bn)
   float milliseconds;
   cudaEventElapsedTime(&milliseconds, startEvent, endEvent);
   bn->runtime = milliseconds / REPEAT_TIMES;
-  printf("measure[BatchNorm]: i(%d %d %d %d) cost(%.4lf)\n",
-         BATCH_SIZE, bn->inputs[0].dim[1], bn->inputs[0].dim[2],
-         bn->inputs[0].dim[3], bn->runtime);
+  if (print_cost)
+    printf("measure[BatchNorm]: i(%d %d %d %d) cost(%.4lf)\n",
+           BATCH_SIZE, bn->inputs[0].dim[1], bn->inputs[0].dim[2],
+           bn->inputs[0].dim[3], bn->runtime);
 }
 

--- a/src/dnnl/batchnorm_mkl.cc
+++ b/src/dnnl/batchnorm_mkl.cc
@@ -22,7 +22,7 @@ static void create_net(BatchNorm* bn, DNNLNet& net, engine& eng, stream& strm,
     memory& inputMem, memory& outputMem, memory& meanMem, memory& varMem, memory& scaleShiftMem,
     void* inputPtr, void* outputPtr, void* meanPtr, void* varPtr, void* biasPtr,
     bool isTraining) {
-  const float eps = BN_MIN_EPSILON;
+  const float eps = epsilon;
   // dimensions.
   int inputC = bn->inputs[0].dim[1];
   // data sizes.
@@ -64,6 +64,11 @@ static void create_net(BatchNorm* bn, DNNLNet& net, engine& eng, stream& strm,
       {DNNL_ARG_VARIANCE, varMem},
       {DNNL_ARG_SCALE_SHIFT, scaleShiftMem},
       {DNNL_ARG_DST, outputMem}}});
+}
+
+float BatchNorm::get_min_epsilon(void)
+{
+  return BN_MIN_EPSILON;
 }
 
 void BatchNorm::map(void)

--- a/src/generator/generator.cc
+++ b/src/generator/generator.cc
@@ -1729,7 +1729,7 @@ int main(int argc, char **argv)
   inputs.push_back(s0);
   std::vector<OpTemp*> ops;
   ops.push_back(new MatmulTemp(AC_MODE_NONE));
-  operator_names[ops.back()] = "Matmul";
+  operator_names[ops.back()] = "MatMul";
   ops.push_back(new ElementTemp(OP_EW_ADD));
   operator_names[ops.back()] = "EWAdd";
   ops.push_back(new ElementTemp(OP_EW_MUL));


### PR DESCRIPTION
Summary of fixes:
- Add Flatten and GlobalAveragePooling ops
- Import biases for Conv/GeMM operators
- Only transpose GeMM inputs if explicitly requested
- Skip transpose when preprocessing weights for final graph
- Add epsilon attribute to BatchNorm
- Ensure Conv padding is same on both sides
- Matmul -> MatMul for ONNX compatibility