### PR TITLE
Make transpose detection less flaky

### DIFF
--- a/src/cudnn/matmul_kernel.cu
+++ b/src/cudnn/matmul_kernel.cu
@@ -65,19 +65,19 @@ void Matmul::forward(bool block)
   int k = inputs[0].dim[numDim-1];
   cublasOperation_t transA, transB;
   int lda, ldb, ldc;
-  if (inputs[0].stride[numDim-2] == 1) {
+  if (mm->inputs[0].stride[numDim-2] == 1 && mm->inputs[0].stride[numDim-1] >= m) {
     transA = CUBLAS_OP_N;
     lda = inputs[0].stride[numDim-1];
   } else {
-    assert(inputs[0].stride[numDim-1] == 1);
+    assert(mm->inputs[0].stride[numDim-1] == 1 && mm->inputs[0].stride[numDim-2] >= k);
     transA = CUBLAS_OP_T;
     lda = inputs[0].stride[numDim-2];
   }
-  if (inputs[1].stride[numDim-2] == 1) {
+  if (mm->inputs[1].stride[numDim-2] == 1 && mm->inputs[1].stride[numDim-1] >= k) {
     transB = CUBLAS_OP_N;
     ldb = inputs[1].stride[numDim-1];
   } else {
-    assert(inputs[1].stride[numDim-1] == 1);
+    assert(mm->inputs[1].stride[numDim-1] == 1 && mm->inputs[0].stride[numDim] >= n);
     transB = CUBLAS_OP_T;
     ldb = inputs[1].stride[numDim-2];
   }

--- a/src/cudnn/matmul_kernel.cu
+++ b/src/cudnn/matmul_kernel.cu
@@ -77,7 +77,7 @@ void Matmul::forward(bool block)
     transB = CUBLAS_OP_N;
     ldb = inputs[1].stride[numDim-1];
   } else {
-    assert(mm->inputs[1].stride[numDim-1] == 1 && mm->inputs[0].stride[numDim] >= n);
+    assert(mm->inputs[1].stride[numDim-1] == 1 && mm->inputs[1].stride[numDim-2] >= n);
     transB = CUBLAS_OP_T;
     ldb = inputs[1].stride[numDim-2];
   }


### PR DESCRIPTION
Just checking stride[numDim-1] or stride[numDim-2] == 1 is not enough.
If a matrix has M x K shape, CUBLAS_OP_T (row-major) will have stride [..., >=K, 1], CUBLAS_OP_N (col-major) will have stride [..., 1, >=M].
If M or K is 1, just checking either of stride is 1 breaks down.
When M == K == 1, one can think there's an ambiguity but that's moot because for 1x1 matrix transpose is nop.