### PR TITLE
Set ONNX opset version to 10

### DIFF
--- a/python/taso/__init__.py
+++ b/python/taso/__init__.py
@@ -933,7 +933,8 @@ def export_onnx(graph):
         graph_outputs.append(helper.make_tensor_value_info(_output_tensor_name(graph, op, idx),
                              TensorProto.FLOAT, graph.get_output_dims(op, idx)))
     onnx_graph = helper.make_graph(graph_nodes, 'main', graph_inputs, graph_outputs, graph_initializers)
-    onnx_model = helper.make_model(onnx_graph, producer_name='TASO Optimized Model')
+    onnx_opset_id = helper.make_opsetid('', 10)
+    onnx_model = helper.make_model(onnx_graph, opset_imports=[onnx_opset_id], producer_name='TASO Optimized Model')
     return onnx_model
 
 def optimize(graph, alpha = 1.0, budget = 1000, print_subst = False):


### PR DESCRIPTION
TASO was developed with ai.onnx opset version 10. Since then, breaking changes have been introduced to operator specifications. Manually pinning down the opset version to 10 is a workaround for these changes.